### PR TITLE
Correction about strides and copying

### DIFF
--- a/featured/01_numpy_performance.ipynb
+++ b/featured/01_numpy_performance.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:b9b65add267b3e6d0058a88dbd981ac0f74d0719f95b4ec1a70421fa85278bfe"
+  "signature": "sha256:6ce1419892fb6f4bccb675e101261c1f4f1da777558ed17cd8fe0f96e8a6b33b"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -979,7 +979,13 @@
      "cell_type": "markdown",
      "metadata": {},
      "source": [
-      "When transposing a matrix, this order is reversed, but the underlying data remains identical. Flattening this array (in column-major order now it has been transposed) requires a copy, as flattening assumes row-major order by default."
+      "More generally, NumPy uses the notion of **strides** to convert between a multidimensional index and the memory location of the underlying (1D) sequence of elements. The specific mapping between `array[i1, i2]` and the relevant byte address of the internal data is given by\n",
+      "\n",
+      "``\n",
+      "offset = array.strides[0] * i1 + array.strides[1] * i2\n",
+      "``\n",
+      "\n",
+      "When reshaping an array, NumPy avoids copies when possible by modifying the ``strides`` attribute. For example, when transposing a matrix, the order of ``strides`` is reversed, but the underlying data remains identical. However, flattening a transposed array cannot be accomplished simply by modifying ``strides`` (try it!), so a copy is needed."
      ]
     },
     {


### PR DESCRIPTION
Clarifies the discussion of how Numpy decides whether to build array copies or views, by mentioning the strides attribute.
