### PR TITLE
Fix recipe 7.8: replaced rmagic by rpy2.ipython

### DIFF
--- a/notebooks/chapter07_stats/08_r.ipynb
+++ b/notebooks/chapter07_stats/08_r.ipynb
@@ -1,7 +1,7 @@
 {
  "metadata": {
   "name": "",
-  "signature": "sha256:46abf376d18c3c56aa9c086ed034bb6a8b8e1b2992fe96908e89748722438026"
+  "signature": "sha256:c584f6c91683455c5dedcca6cf743fbf9bf40973b6c9ea0531bcf9a3c794a7cb"
  },
  "nbformat": 3,
  "nbformat_minor": 0,
@@ -97,7 +97,7 @@
      "cell_type": "code",
      "collapsed": false,
      "input": [
-      "%load_ext rmagic"
+      "%load_ext rpy2.ipython"
      ],
      "language": "python",
      "metadata": {},


### PR DESCRIPTION
In newer versions of rpy2, the IPython extension with the R magic is `rpy2.ipython` and not `rmagic` as stated in the book.
