### PR TITLE
Upgraded Chapter 01 Recipe 05 to IPython 4.0.0

### DIFF
--- a/notebooks/chapter01_basic/05_config.ipynb
+++ b/notebooks/chapter01_basic/05_config.ipynb
@@ -60,6 +60,7 @@
    "metadata": {},
    "source": [
     "from traitlets import Int, Float, Unicode, Bool\n",
+    "#from IPython.utils.traitlets import Int, Float, Unicode, Bool # IPython < 4.x\n",
     "from IPython.core.magic import (Magics, magics_class, line_magic)\n",
     "import numpy as np"
    ]

--- a/notebooks/chapter01_basic/05_config.ipynb
+++ b/notebooks/chapter01_basic/05_config.ipynb
@@ -25,7 +25,8 @@
     "%%writefile random_magics.py\n",
     "# NOTE: We create the `random_magics.py` file here so that \n",
     "# you don't have to do it...\n",
-    "from IPython.utils.traitlets import Int, Float, Unicode, Bool\n",
+    "from traitlets import Int, Float, Unicode, Bool\n",
+    "#from IPython.utils.traitlets import Int, Float, Unicode, Bool # IPython < 4.x\n",
     "from IPython.core.magic import (Magics, magics_class, line_magic)\n",
     "import numpy as np\n",
     "\n",
@@ -58,7 +59,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "from IPython.utils.traitlets import Int, Float, Unicode, Bool\n",
+    "from traitlets import Int, Float, Unicode, Bool\n",
     "from IPython.core.magic import (Magics, magics_class, line_magic)\n",
     "import numpy as np"
    ]
@@ -260,7 +261,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.2"
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The new version of Python/Jupyter (starting from IPython version 4.0.0) brings some backward-incompatible changes. This pull request contains updates to just one notebook to make it runnable under Python 4.0.0.

I do not know what the policy is for such changes in this repository, so I assumed it is the same as for Python 3.x/2.x incompatibilities, i.e. the code is for the latest version, with a comment for previous versions. Maybe a dedicated branch will be a better idea, but more maintenance work.

If this approach is OK, I can submit more patches, one notebook at a time.