### PR TITLE
Upgraded Chapter 01 Recipe 06 to IPython 4.0.0

### DIFF
--- a/notebooks/chapter01_basic/06_kernel.ipynb
+++ b/notebooks/chapter01_basic/06_kernel.ipynb
@@ -18,7 +18,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "This recipe has been tested on the development version of IPython 3. It should work on the final version of IPython 3 with no or minimal changes. We give all references about wrapper kernels and messaging protocols at the end of this recipe."
+    "This recipe has been tested on IPython 4. It should work on IPython 3 with minimal changes. We give all references about wrapper kernels and messaging protocols at the end of this recipe."
    ]
   },
   {
@@ -39,7 +39,8 @@
     "%%writefile plotkernel.py\n",
     "# NOTE: We create the `plotkernel.py` file here so that \n",
     "# you don't have to do it...\n",
-    "from IPython.kernel.zmq.kernelbase import Kernel\n",
+    "from ipykernel.kernelbase import Kernel\n",
+    "#from IPython.kernel.zmq.kernelbase import Kernel # IPython < 4.x\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from io import BytesIO\n",
@@ -64,10 +65,17 @@
     "class PlotKernel(Kernel):\n",
     "    implementation = 'Plot'\n",
     "    implementation_version = '1.0'\n",
-    "    language = 'python'  # will be used for\n",
-    "                         # syntax highlighting\n",
-    "    language_version = ''\n",
     "    banner = \"Simple plotting\"\n",
+    "    language_info = {\n",
+    "        'name': 'python', # will be used for syntax highlighting\n",
+    "        'version': '',\n",
+    "        'file_extension': '.plot',\n",
+    "        'mimetype': 'text/x-python'\n",
+    "    }\n",
+    "    # language and language_version needed only for protocol version < 5.0\n",
+    "    language = language_info['name']\n",
+    "    language_version = language_info['version']\n",
+    "\n",
     "    \n",
     "    def do_execute(self, code, silent,\n",
     "                   store_history=True,\n",
@@ -98,7 +106,7 @@
     "            # We prepare the response with our rich data\n",
     "            # (the plot).\n",
     "            content = {\n",
-    "                'source': 'kernel',\n",
+    "                #'source': 'kernel',  # IPython < 4.x\n",
     "\n",
     "                # This dictionary may contain different\n",
     "                # MIME representations of the output.\n",
@@ -129,7 +137,8 @@
     "               }\n",
     "\n",
     "if __name__ == '__main__':\n",
-    "    from IPython.kernel.zmq.kernelapp import IPKernelApp\n",
+    "    from ipykernel.kernelapp import IPKernelApp\n",
+    "    #from IPython.kernel.zmq.kernelapp import IPKernelApp # IPython < 4.x\n",
     "    IPKernelApp.launch_instance(kernel_class=PlotKernel)"
    ]
   },
@@ -137,15 +146,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "1. First, we create a file `plotkernel.py`. This file will contain the implementation of our custom kernel. Let's import a few modules."
+    "1\\. First, we create a file `plotkernel.py`. This file will contain the implementation of our custom kernel. Let's import a few modules."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
-    "from IPython.kernel.zmq.kernelbase import Kernel\n",
+    "```python\n",
+    "from ipykernel.kernelbase import Kernel\n",
+    "#from IPython.kernel.zmq.kernelbase import Kernel # IPython < 4.x\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from io import BytesIO\n",
@@ -156,14 +166,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "2. We write a function that returns a PNG base64-encoded representation of a matplotlib figure."
+    "2\\. We write a function that returns a PNG base64-encoded representation of a matplotlib figure."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
+    "```python\n",
     "def _to_png(fig):\n",
     "    \"\"\"Return a base64-encoded PNG from a \n",
     "    matplotlib figure.\"\"\"\n",
@@ -178,14 +188,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "3. Now, we write a function that parses a code string which has the form `y = f(x)`, and returns a NumPy function. Here, `f` is an arbitrary Python expression that can use NumPy functions."
+    "3\\. Now, we write a function that parses a code string which has the form `y = f(x)`, and returns a NumPy function. Here, `f` is an arbitrary Python expression that can use NumPy functions."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
+    "```python\n",
     "_numpy_namespace = {n: getattr(np, n) \n",
     "                    for n in dir(np)}\n",
     "def _parse_function(code):\n",
@@ -198,36 +208,42 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "4. For our new wrapper kernel, we create a class deriving from `Kernel`. There are a few metadata fields we need to provide."
+    "4\\. For our new wrapper kernel, we create a class deriving from `Kernel`. There are a few metadata fields we need to provide."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
+    "```python\n",
     "class PlotKernel(Kernel):\n",
     "    implementation = 'Plot'\n",
     "    implementation_version = '1.0'\n",
-    "    language = 'python'  # will be used for\n",
-    "                         # syntax highlighting\n",
-    "    language_version = ''\n",
     "    banner = \"Simple plotting\"\n",
-    "    ```"
+    "    language_info = {\n",
+    "        'name': 'python', # will be used for syntax highlighting\n",
+    "        'version': '',\n",
+    "        'file_extension': '.plot',\n",
+    "        'mimetype': 'text/x-python'\n",
+    "    }\n",
+    "    # language and language_version needed only for protocol version < 5.0\n",
+    "    language = language_info['name']\n",
+    "    language_version = language_info['version']\n",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "5. In this class, we implement a `do_execute()` method that takes code as input, and sends responses to the client."
+    "5\\. In this class, we implement a `do_execute()` method that takes code as input, and sends responses to the client."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
+    "```python\n",
     "def do_execute(self, code, silent,\n",
     "                   store_history=True,\n",
     "                   user_expressions=None,\n",
@@ -292,16 +308,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "6. Finally, we add the following lines at the end of the file."
+    "6\\. Finally, we add the following lines at the end of the file."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
+    "```python\n",
     "if __name__ == '__main__':\n",
-    "    from IPython.kernel.zmq.kernelapp import IPKernelApp\n",
+    "    from ipykernel.kernelapp import IPKernelApp\n",
+    "    #from IPython.kernel.zmq.kernelapp import IPKernelApp # IPython < 4.x\n",
     "    IPKernelApp.launch_instance(kernel_class=PlotKernel)```"
    ]
   },
@@ -309,21 +326,81 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "7. Our kernel is ready! The next step is to indicate to IPython that this new kernel is available. To do this, we need to create a **kernel spec** `kernel.json` file and put it in `~/.ipython/kernels/plot/`. This file contains the following lines:"
+    "7\\. Our kernel is ready! The next step is to indicate to IPython that this new kernel is available. To do this, we need to create a **kernel spec** `kernel.json` file in a directory named after our kernel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!mkdir plot"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```\n",
+    "The `kernel.json` file contains the following lines:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "%%writefile plot/kernel.json\n",
     "{\n",
     " \"argv\": [\"python\", \"-m\",\n",
     "          \"plotkernel\", \"-f\",\n",
     "          \"{connection_file}\"],\n",
     " \"display_name\": \"Plot\",\n",
     " \"language\": \"python\"\n",
-    "}```"
+    "}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you are using IPython 3, simply move the directory `plot` (with `kernel.json` in it) to `~/.ipython/kernels/`. This may still work (deprecated) for IPython 4, but since IPython 4 is Jupyter based, the proper way is to copy the whole directory to the appropriate location using the `jupyter` command:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!jupyter kernelspec install plot --user --replace"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The main argument to this command is the path to the directory containing the kernel spec. The option `--user` instructs Jupyter to install the kernel for the current user only. The option `--replace` overwrites any already installed kernel with the same name (if exists).\n",
+    "\n",
+    "The installation can be verified by listing all kernels known to Jupyter and their locations:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "!jupyter kernelspec list"
    ]
   },
   {
@@ -337,7 +414,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "8. In IPython 3, you can launch a notebook with this kernel from the IPython notebook dashboard. However, this feature is not available at the time of writing. An alternative (that is probably going to be deprecated by the time IPython 3 is released) is to run the following command in a terminal:"
+    "8\\. In IPython 4, you can launch a notebook with this kernel from the IPython notebook dashboard, in a dropdown menu from the ‘New’ button.\n",
+    "\n",
+    "In IPython 3, this feature may not be available in all versions. An alternative (deprecated) is to run the following command in a terminal:"
    ]
   },
   {
@@ -353,7 +432,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "9. Finally, in a new notebook backed by our custom plot kernel, we can simply write mathematical equations `y=f(x)`. The corresponding graph appears in the output area."
+    "9\\. Finally, in a new notebook backed by our custom plot kernel, we can simply write mathematical equations `y=f(x)`. The corresponding graph appears in the output area."
    ]
   },
   {
@@ -382,7 +461,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.2"
+   "version": "3.5.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
*Please note:*
This recipe is about custom kernels but since IPython 4 comes with the Big Split into Jupyter and the rest of IPython, the upgrade changes here are more substantial. I have tested the changes on OS X and Windows 10 (with Anaconda).

Since I was already changing much, I also took the liberty to fix the recipe steps numbering (markdown was numbering every step as 1.) and syntax highlighting of Python snippets.

 @rossant, please let me know if this is OK. I put the updates on a separate branch in case more fixups are needed.
