### PR TITLE
The `IPython.kernel` package has been deprecated.

### DIFF
--- a/notebooks/chapter01_basic/06_kernel.ipynb
+++ b/notebooks/chapter01_basic/06_kernel.ipynb
@@ -39,7 +39,9 @@
     "%%writefile plotkernel.py\n",
     "# NOTE: We create the `plotkernel.py` file here so that \n",
     "# you don't have to do it...\n",
-    "from IPython.kernel.zmq.kernelbase import Kernel\n",
+    "# from IPython.kernel.zmq.kernelbase import Kernel\n",
+    "# The `IPython.kernel` package has been deprecated.\n",
+    "from from ipykernel.kernelbase import Kernel\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from io import BytesIO\n",
@@ -129,7 +131,9 @@
     "               }\n",
     "\n",
     "if __name__ == '__main__':\n",
-    "    from IPython.kernel.zmq.kernelapp import IPKernelApp\n",
+    "#   from IPython.kernel.zmq.kernelapp import IPKernelApp\n",
+    "#   The `IPython.kernel` package has been deprecated.\n",
+    "    from ipykernel.kernelapp import IPKernelApp\n",
     "    IPKernelApp.launch_instance(kernel_class=PlotKernel)"
    ]
   },
@@ -145,7 +149,9 @@
    "metadata": {},
    "source": [
     "```\n",
-    "from IPython.kernel.zmq.kernelbase import Kernel\n",
+    "# from IPython.kernel.zmq.kernelbase import Kernel\n",
+    "# The `IPython.kernel` package has been deprecated.\n",
+    "from ipykernel.kernelbase import Kernel\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "from io import BytesIO\n",
@@ -301,7 +307,9 @@
    "source": [
     "```\n",
     "if __name__ == '__main__':\n",
-    "    from IPython.kernel.zmq.kernelapp import IPKernelApp\n",
+    "#   from IPython.kernel.zmq.kernelapp import IPKernelApp\n",
+    "#   The `IPython.kernel` package has been deprecated.\n",
+    "    from ipykernel.kernelapp import IPKernelApp\n",
     "    IPKernelApp.launch_instance(kernel_class=PlotKernel)```"
    ]
   },
@@ -345,7 +353,7 @@
    "metadata": {},
    "source": [
     "```\n",
-    "ipython notebook --KernelManager.kernel_cmd=\"['python', '-m', 'plotkernel', '-f', '{connection_file}']\"\n",
+    "jupyter notebook --KernelManager.kernel_cmd=\"['python', '-m', 'plotkernel', '-f', '{connection_file}']\"\n",
     "```"
    ]
   },


### PR DESCRIPTION
The `IPython.kernel` package has been deprecated.
So I changed `IPython.kernel` to `ipykernel`.