### PR TITLE
Upgraded Recipe 3.2 to IPython 4

### DIFF
--- a/notebooks/chapter03_notebook/02_nbformat.ipynb
+++ b/notebooks/chapter03_notebook/02_nbformat.ipynb
@@ -205,7 +205,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "7. Now, we are going to use nbconvert to convert our text notebook to other formats. This tool can be used from the command-line. Note that the API of nbconvert may change in future versions. Here, we convert the notebook to an HTML document."
+    "7. Now, we are going to use nbconvert to convert our text notebook to other formats. This tool can be used from the command-line (if you are using IPython < 4.x, replace command `jupyter` with `ipython`). Here, we convert the notebook to an HTML document."
    ]
   },
   {
@@ -216,7 +216,7 @@
    },
    "outputs": [],
    "source": [
-    "!ipython nbconvert --to html data/test.ipynb"
+    "!jupyter nbconvert --to html data/test.ipynb"
    ]
   },
   {
@@ -280,7 +280,7 @@
    },
    "outputs": [],
    "source": [
-    "!ipython nbconvert --to latex --template mytemplate data/test.ipynb\n",
+    "!jupyter nbconvert --to latex --template mytemplate data/test.ipynb\n",
     "!pdflatex test.tex"
    ]
   },
@@ -310,7 +310,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.4.2"
+   "version": "3.5.1"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Command `ipython` causes depreciation warning that it will stop working in the future.