### PR TITLE
replace cythonmagic to Cython

### DIFF
--- a/notebooks/chapter05_hpc/04_cython.ipynb
+++ b/notebooks/chapter05_hpc/04_cython.ipynb
@@ -114,7 +114,8 @@
    },
    "outputs": [],
    "source": [
-    "%load_ext cythonmagic"
+    "#%load_ext cythonmagic\n",
+    "%load_ext Cython"
    ]
   },
   {

--- a/notebooks/chapter05_hpc/05_ray_2.ipynb
+++ b/notebooks/chapter05_hpc/05_ray_2.ipynb
@@ -52,7 +52,8 @@
    },
    "outputs": [],
    "source": [
-    "%load_ext cythonmagic"
+    "#%load_ext cythonmagic\n",
+    "%load_ext Cython"
    ]
   },
   {

--- a/notebooks/chapter05_hpc/05_ray_3.ipynb
+++ b/notebooks/chapter05_hpc/05_ray_3.ipynb
@@ -52,7 +52,8 @@
    },
    "outputs": [],
    "source": [
-    "%load_ext cythonmagic"
+    "#%load_ext cythonmagic\n",
+    "%load_ext Cython"
    ]
   },
   {

--- a/notebooks/chapter05_hpc/05_ray_4.ipynb
+++ b/notebooks/chapter05_hpc/05_ray_4.ipynb
@@ -56,7 +56,8 @@
    },
    "outputs": [],
    "source": [
-    "%load_ext cythonmagic"
+    "#%load_ext cythonmagic\n",
+    "%load_ext Cython"
    ]
   },
   {

--- a/notebooks/chapter05_hpc/05_ray_5.ipynb
+++ b/notebooks/chapter05_hpc/05_ray_5.ipynb
@@ -56,7 +56,8 @@
    },
    "outputs": [],
    "source": [
-    "%load_ext cythonmagic"
+    "#%load_ext cythonmagic\n",
+    "%load_ext Cython"
    ]
   },
   {


### PR DESCRIPTION
The Cython magic has been moved to the Cython package.
"%load_ext cythonmagic" doesn't work.